### PR TITLE
Improve WASM error handling

### DIFF
--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -422,7 +422,6 @@ dependencies = [
  "getrandom 0.1.16",
  "hex",
  "kzen-paillier",
- "libsecp256k1",
  "multi-party-ecdsa",
  "once_cell",
  "rand 0.6.5",
@@ -1442,9 +1441,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -1454,9 +1453,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1481,9 +1480,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1491,9 +1490,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1516,9 +1515,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
 
 [[package]]
 name = "wasm-bindgen-test"

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 common = {path = "../common"}
 getrandom = {version = "0.1.16", features = ["wasm-bindgen"]}
 curv-kzen = {version = "0.9", features = ["num-bigint"], default-features = false}
-wasm-bindgen = { version = "0.2.76", features = ["serde-serialize"] }
+wasm-bindgen = { version = "0.2.79", features = ["serde-serialize"] }
 wasm-bindgen-rayon = "1.0"
 rand = { version="0.6.5", features = ["wasm-bindgen"] }
 #rand = { version="0.7.3", features = ["getrandom"] }
@@ -18,7 +18,6 @@ console_error_panic_hook = "0.1.6"
 sha2 = "0.9"
 sha3 = "0.10"
 serde = {version = "1", features = ["derive"]}
-libsecp256k1 = "0.3.2"
 hex = "0.4"
 round-based = "0.1"
 once_cell = "1.9"

--- a/wasm/src/gg2020/sign.rs
+++ b/wasm/src/gg2020/sign.rs
@@ -18,6 +18,9 @@ use wasm_bindgen::prelude::*;
 
 //use crate::{console_log, log};
 
+const ERR_NO_STATE_MACHINE: &str =
+    "sign is not prepared, perhaps you forgot to call signInit()";
+
 static SIGN: Lazy<Arc<Mutex<Option<OfflineStage>>>> =
     Lazy::new(|| Arc::new(Mutex::new(None)));
 
@@ -61,71 +64,85 @@ pub struct SignResult {
 }
 
 #[wasm_bindgen(js_name = "signInit")]
-pub fn sign_init(index: JsValue, participants: JsValue, local_key: JsValue) {
-    let index: u16 = index.into_serde().unwrap();
-    let participants: Vec<u16> = participants.into_serde().unwrap();
-    let local_key: LocalKey<Secp256k1> = local_key.into_serde().unwrap();
-    let mut writer = SIGN.lock().unwrap();
-    *writer = Some(
-        OfflineStage::new(index, participants.clone(), local_key).unwrap(),
-    );
+pub fn sign_init(
+    index: JsValue,
+    participants: JsValue,
+    local_key: JsValue,
+) -> Result<(), JsError> {
+    let index: u16 = index.into_serde()?;
+    let participants: Vec<u16> = participants.into_serde()?;
+    let local_key: LocalKey<Secp256k1> = local_key.into_serde()?;
+    let mut writer = SIGN.lock()?;
+    *writer = Some(OfflineStage::new(index, participants.clone(), local_key)?);
+    Ok(())
 }
 
 #[wasm_bindgen(js_name = "signHandleIncoming")]
-pub fn sign_handle_incoming(message: JsValue) {
+pub fn sign_handle_incoming(message: JsValue) -> Result<(), JsError> {
     let message: Msg<<OfflineStage as StateMachine>::MessageBody> =
-        message.into_serde().unwrap();
-    let mut writer = SIGN.lock().unwrap();
-    let state = writer.as_mut().unwrap();
-    state.handle_incoming(message).unwrap();
+        message.into_serde()?;
+    let mut writer = SIGN.lock()?;
+    let state = writer
+        .as_mut()
+        .ok_or_else(|| JsError::new(ERR_NO_STATE_MACHINE))?;
+    state.handle_incoming(message)?;
+    Ok(())
 }
 
 #[wasm_bindgen(js_name = "signProceed")]
-pub fn sign_proceed() -> JsValue {
-    let mut writer = SIGN.lock().unwrap();
-    let state = writer.as_mut().unwrap();
+pub fn sign_proceed() -> Result<JsValue, JsError> {
+    let mut writer = SIGN.lock()?;
+    let state = writer
+        .as_mut()
+        .ok_or_else(|| JsError::new(ERR_NO_STATE_MACHINE))?;
     if state.wants_to_proceed() {
-        state.proceed().unwrap();
+        state.proceed()?;
         let messages = state.message_queue().drain(..).collect();
         let round = state.current_round();
         let messages = RoundMsg::from_round(round, messages);
-        JsValue::from_serde(&(round, &messages)).unwrap()
+        Ok(JsValue::from_serde(&(round, &messages))?)
     } else {
-        JsValue::from_serde(&false).unwrap()
+        Ok(JsValue::from_serde(&false)?)
     }
 }
 
 #[wasm_bindgen(js_name = "signPartial")]
-pub fn sign_partial(message: JsValue) -> JsValue {
-    let message: String = message.into_serde().unwrap();
+pub fn sign_partial(message: JsValue) -> Result<JsValue, JsError> {
+    let message: String = message.into_serde()?;
 
-    let mut writer = SIGN.lock().unwrap();
-    let state = writer.as_mut().unwrap();
-    let completed_offline_stage = state.pick_output().unwrap().unwrap();
+    let mut writer = SIGN.lock()?;
+    let state = writer
+        .as_mut()
+        .ok_or_else(|| JsError::new(ERR_NO_STATE_MACHINE))?;
+    let completed_offline_stage = state.pick_output().unwrap()?;
     let data = BigInt::from_bytes(message.as_bytes());
     let (_sign, partial) =
-        SignManual::new(data.clone(), completed_offline_stage.clone()).unwrap();
+        SignManual::new(data.clone(), completed_offline_stage.clone())?;
 
-    let mut writer = RESULT.lock().unwrap();
+    let mut writer = RESULT.lock()?;
     *writer = Some((completed_offline_stage, data));
 
-    JsValue::from_serde(&partial).unwrap()
+    Ok(JsValue::from_serde(&partial)?)
 }
 
 #[wasm_bindgen(js_name = "signCreate")]
-pub fn sign_create(partials: JsValue) -> JsValue {
-    let partials: Vec<PartialSignature> = partials.into_serde().unwrap();
+pub fn sign_create(partials: JsValue) -> Result<JsValue, JsError> {
+    let partials: Vec<PartialSignature> = partials.into_serde()?;
 
-    let mut writer = RESULT.lock().unwrap();
-    let state = writer.as_mut().unwrap();
+    let mut writer = RESULT.lock()?;
+    let state = writer
+        .as_mut()
+        .ok_or_else(|| JsError::new(ERR_NO_STATE_MACHINE))?;
     let (completed_offline_stage, data) = state;
     let pk = completed_offline_stage.public_key().clone();
 
     let (sign, _partial) =
-        SignManual::new(data.clone(), completed_offline_stage.clone()).unwrap();
+        SignManual::new(data.clone(), completed_offline_stage.clone())?;
 
-    let signature = sign.complete(&partials).unwrap();
-    verify(&signature, &pk, &data).unwrap();
+    let signature = sign.complete(&partials)?;
+    verify(&signature, &pk, &data).map_err(|e| {
+        JsError::new(&format!("failed to verify signature: {:?}", e))
+    })?;
 
     let public_key = pk.to_bytes(false).to_vec();
     let result = SignResult {
@@ -136,9 +153,9 @@ pub fn sign_create(partials: JsValue) -> JsValue {
 
     *writer = None;
     {
-        let mut writer = SIGN.lock().unwrap();
+        let mut writer = SIGN.lock()?;
         *writer = None;
     }
 
-    JsValue::from_serde(&result).unwrap()
+    Ok(JsValue::from_serde(&result)?)
 }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -30,10 +30,9 @@ mod gg2020;
 mod utils;
 
 #[wasm_bindgen]
-pub fn sha256(message: JsValue) -> JsValue {
-    let message: String = message.into_serde::<String>().unwrap();
+pub fn sha256(message: JsValue) -> Result<JsValue, JsError> {
+    let message: String = message.into_serde()?;
     let mut hasher = Sha256::new();
     hasher.update(&message);
-    let result = hex::encode(hasher.finalize());
-    JsValue::from_serde(&result).unwrap()
+    Ok(JsValue::from_serde(&hex::encode(hasher.finalize()))?)
 }


### PR DESCRIPTION
So that errors are propagated via `Result` to something that is thrown on the Javascript side.