### PR TITLE
Tidy EcdsaWorker type.

### DIFF
--- a/client/src/mpc/index.ts
+++ b/client/src/mpc/index.ts
@@ -1,6 +1,24 @@
+import { KeyGenerator, Signer } from "ecdsa-wasm";
+export { KeyGenerator, Signer } from "ecdsa-wasm";
+
 export enum SessionKind {
   KEYGEN = "keygen",
   SIGN = "sign",
+}
+
+export interface EcdsaWorker {
+  KeyGenerator(
+    parameters: Parameters,
+    partySignup: PartySignup
+  ): Promise<KeyGenerator>;
+
+  Signer(
+    index: number,
+    participants: number[],
+    localKey: LocalKey
+  ): Promise<Signer>;
+
+  sha256(value: string): Promise<string>;
 }
 
 // Message is sent by a client.

--- a/client/src/mpc/keygen.ts
+++ b/client/src/mpc/keygen.ts
@@ -1,6 +1,5 @@
-import { Message, KeyShare, SessionInfo } from ".";
+import { Message, KeyShare, SessionInfo, EcdsaWorker, KeyGenerator } from ".";
 import { WebSocketClient } from "./clients/websocket";
-import { EcdsaWorker, KeyGenerator } from "../worker";
 
 import {
   Round,

--- a/client/src/mpc/sign.ts
+++ b/client/src/mpc/sign.ts
@@ -1,7 +1,14 @@
-import { Message, KeyShare, SessionInfo, SignMessage, PartySignup } from ".";
+import {
+  Message,
+  KeyShare,
+  SessionInfo,
+  SignMessage,
+  PartySignup,
+  EcdsaWorker,
+  Signer,
+} from ".";
 import { WebSocketClient } from "./clients/websocket";
 import { GroupInfo } from "../store/group";
-import { EcdsaWorker, Signer } from "../worker";
 
 import {
   Round,

--- a/client/src/routes/keygen.tsx
+++ b/client/src/routes/keygen.tsx
@@ -6,7 +6,6 @@ import { useParams, useNavigate, NavigateFunction } from "react-router-dom";
 import { WebSocketContext } from "../websocket-provider";
 import { AppDispatch, RootState } from "../store";
 
-import { EcdsaWorker } from "../worker";
 import { WorkerContext } from "../worker-provider";
 import {
   saveKeyShare,
@@ -15,7 +14,7 @@ import {
   KeyStorage,
 } from "../key-storage";
 
-import { KeyShare, Session, SessionKind } from "../mpc";
+import { KeyShare, Session, SessionKind, EcdsaWorker } from "../mpc";
 import { generateKeyShare } from "../mpc/keygen";
 
 import { WebSocketStream, WebSocketSink } from "../mpc/transports/websocket";
@@ -26,7 +25,7 @@ const copyToClipboard = async (
 ) => {
   e.preventDefault();
   try {
-    await navigator.clipboard.writeText(text);
+    await window.navigator.clipboard.writeText(text);
   } catch (e) {
     console.error("Permission to write to clipboard was denied");
   }
@@ -115,9 +114,7 @@ class Keygen extends Component<KeygenProps, KeygenStateProps> {
 
         // Keep this to check we don't regress on #49
         if (runningSession) {
-          throw new Error(
-            `keygen session ${sessionId} is already running`
-          );
+          throw new Error(`keygen session ${sessionId} is already running`);
         }
 
         // Guard against running multiple key generation sessions

--- a/client/src/routes/sign.tsx
+++ b/client/src/routes/sign.tsx
@@ -5,11 +5,10 @@ import { v4 as uuidv4 } from "uuid";
 
 import { groupSelector, GroupInfo } from "../store/group";
 import { keygenSelector } from "../store/keygen";
-import { EcdsaWorker } from "../worker";
 import { WorkerContext } from "../worker-provider";
 import { WebSocketClient } from "../mpc/clients/websocket";
 import { WebSocketContext } from "../websocket-provider";
-import { SessionKind, KeyShare, SignResult } from "../mpc";
+import { SessionKind, KeyShare, SignResult, EcdsaWorker } from "../mpc";
 import { sign } from "../mpc/sign";
 
 import { WebSocketStream, WebSocketSink } from "../mpc/transports/websocket";
@@ -116,12 +115,9 @@ const Proposal = ({
 
     websocket.once("sessionSignup", async (sessionId: string) => {
       if (sessionId === session.uuid) {
-
         // Keep this to check we don't regress on #49
         if (runningSession) {
-          throw new Error(
-            `sign session ${sessionId} is already running`
-          );
+          throw new Error(`sign session ${sessionId} is already running`);
         }
 
         if (!runningSession) {

--- a/client/src/worker.ts
+++ b/client/src/worker.ts
@@ -1,24 +1,5 @@
-import { LocalKey, Parameters, PartySignup } from "./mpc";
-
 import init, { initThreadPool, KeyGenerator, Signer, sha256 } from "ecdsa-wasm";
 import * as Comlink from "comlink";
-
-export { KeyGenerator, Signer } from "ecdsa-wasm";
-
-export interface EcdsaWorker {
-  KeyGenerator(
-    parameters: Parameters,
-    partySignup: PartySignup
-  ): Promise<KeyGenerator>;
-
-  Signer(
-    index: number,
-    participants: number[],
-    localKey: LocalKey
-  ): Promise<Signer>;
-
-  sha256(value: string): Promise<string>;
-}
 
 // Temporary hack for getRandomValues() error
 const getRandomValues = crypto.getRandomValues;
@@ -34,12 +15,10 @@ crypto.getRandomValues = function <T extends ArrayBufferView | null>(
 // For top-level await typescript wants `target` to be es2017
 // but this generates a "too much recursion" runtime error so
 // we avoid top-level await for now
-void (async function () {
-  console.log("Worker is initializing...");
-  await init();
-  //await initThreadPool(navigator.hardwareConcurrency);
-  await initThreadPool(1);
-})();
+console.log("Worker is initializing...");
+await init();
+//await initThreadPool(navigator.hardwareConcurrency);
+await initThreadPool(1);
 
 Comlink.expose({
   KeyGenerator,

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
-    "lib": ["dom"],
+    "lib": ["webworker", "dom"],
     "outDir": "./dist/",
     "noImplicitAny": true,
-    "module": "es2022",
-    "target": "es5",
+    "module": "esnext",
+    "target": "esnext",
     "jsx": "react",
     "allowJs": true,
     "skipLibCheck": true,

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -45,6 +45,6 @@ module.exports = {
   experiments: {
     //syncWebAssembly: true,
     asyncWebAssembly: true,
-    //topLevelAwait: true,
+    topLevelAwait: true,
   },
 };


### PR DESCRIPTION
So it is no longer declared in the worker which means that we are no
longer statically importing the worker file which is also run
dynamically via `new Worker`.

Use top-level await to initialize the WASM and update typescript
configuration.